### PR TITLE
trigger build as s390 package missing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  #trigger: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:


### PR DESCRIPTION
trigger build as s390 dependency missing for opentelemetry-python-feedstock